### PR TITLE
Fix issues on older version of libcapstone and implement aarch64 support

### DIFF
--- a/src/hook.c
+++ b/src/hook.c
@@ -622,11 +622,17 @@ install_hook(void)
 
 	query_all_org_func_addr();
 	allocate_memory_block_for_patches();
-
-	if (cs_open(CS_ARCH_X86, CS_MODE_64, &handle)) {
-		printf("ERROR: Failed to initialize engine!\n");
-		exit(1);
-	}
+#if defined(__x86_64__)
+		if (cs_open(CS_ARCH_X86, CS_MODE_64, &handle)) {
+			printf("ERROR: Failed to initialize engine!\n");
+			exit(1);
+		}
+#elif defined(__aarch64__)
+		if (cs_open(CS_ARCH_ARM64, CS_MODE_ARM, &handle)) {
+			printf("ERROR: Failed to initialize engine!\n");
+			exit(1);
+		}
+#endif
     cs_opt_skipdata skipdata = {
        .mnemonic = "db",
     };
@@ -673,7 +679,8 @@ install_hook(void)
 				printf("Failed to disassemble code.\n");
 				exit(1);
 			}
-
+		
+#if defined(__x86_64__)
 			for (idx_inst = 0; idx_inst < num_inst; idx_inst++) {
 				OffsetList[idx_inst] = insn[idx_inst].address;
 				if (OffsetList[idx_inst] >= JMP_INSTRCTION_LEN) {
@@ -694,16 +701,62 @@ install_hook(void)
 						tramp_list[nFunc_InBlk].offset_rIP_var = RIP_Offset;
 				}
 			}
+#elif defined(__aarch64__)
+			for (idx_inst = 0; idx_inst < num_inst; idx_inst++) {
+				OffsetList[idx_inst] = insn[idx_inst].address;
+				if (OffsetList[idx_inst] >= JMP_INSTRCTION_LEN) {
+					tramp_list[nFunc_InBlk].saved_code_len =
+					    OffsetList[idx_inst];
+					// TODO: need to add the code to handle relative PC offset
+					break;
+				}
+			}
+#endif
+#if defined(__x86_64__)
+				memcpy(tramp_list[nFunc_InBlk].bounce, instruction_bounce, BOUNCE_CODE_LEN);
+				/* the address of new function */
+				*((unsigned long int *)(tramp_list[nFunc_InBlk].bounce +
+							OFFSET_NEW_FUNC_ADDR)) =
+					(unsigned long int)(module_list[idx_mod].new_func_addr_list[iFunc]);
+#elif defined(__aarch64__)
+			    uint32_t movz_op = 0xd2800000;
+				uint32_t movk_op = 0xf2800000;
+				uint32_t b_op = 0x14000000;
+				uint32_t current_op = 0;
 
-			memcpy(tramp_list[nFunc_InBlk].bounce, instruction_bounce, BOUNCE_CODE_LEN);
-			/* the address of new function */
-			*((unsigned long int *)(tramp_list[nFunc_InBlk].bounce +
-						OFFSET_NEW_FUNC_ADDR)) =
-			    (unsigned long int)(module_list[idx_mod].new_func_addr_list[iFunc]);
+				void *current_ptr = &tramp_list[nFunc_InBlk].bounce;
+				uint64_t target = (uint64_t)module_list[idx_mod].new_func_addr_list[iFunc];
+
+				// movz x16, #<imm>
+				current_op = movz_op | 16;
+				current_op |= (target & 0xffff) << 5;
+				memcpy(current_ptr, &current_op, sizeof(current_op));
+				current_ptr += sizeof(current_op);
+
+				// movk x16, #<imm>, lsl #16
+				current_op = movk_op | 16;
+				current_op |= ((target >> 16) & 0xffff) << 5;
+				current_op |= (1 << 21); // lsl #16
+				memcpy(current_ptr, &current_op, sizeof(current_op));
+				current_ptr += sizeof(current_op);
+
+				// movk x16, #<imm>, lsl #32
+				current_op = movk_op | 16;
+				current_op |= ((target >> 32) & 0xffff) << 5;
+				current_op |= (2 << 21); // lsl #32
+				memcpy(current_ptr, &current_op, sizeof(current_op));
+				current_ptr += sizeof(current_op);
+
+				// Jump to the target address 
+				current_op = 0xD61F0200 | (16 << 5);
+				memcpy(current_ptr, &current_op, sizeof(current_op));
+				current_ptr += sizeof(current_op);
+#endif
 
 			memcpy(tramp_list[nFunc_InBlk].trampoline,
 			       tramp_list[nFunc_InBlk].addr_org_func,
 			       tramp_list[nFunc_InBlk].saved_code_len);
+#if defined(__x86_64__)
 			/* E9 is a jmp instruction */
 			tramp_list[nFunc_InBlk].trampoline[tramp_list[nFunc_InBlk].saved_code_len] =
 			    0xE9;
@@ -712,7 +765,14 @@ install_hook(void)
 					   0xFFFFFFFF);
 			*((int *)(tramp_list[nFunc_InBlk].trampoline +
 				  tramp_list[nFunc_InBlk].saved_code_len + 1)) = Jmp_Offset;
+#elif defined(__aarch64__)
+			current_ptr = &tramp_list[nFunc_InBlk].trampoline[tramp_list[nFunc_InBlk].saved_code_len];
+			uint32_t offset = (uint32_t) ((tramp_list[nFunc_InBlk].addr_org_func + 4 - current_ptr) & 0x0FFFFFFF);
+			current_op = b_op | (offset >> 2);
+			memcpy(current_ptr, &current_op, sizeof(current_op));
+#endif
 
+#if defined(__x86_64__)
 			if (tramp_list[nFunc_InBlk].offset_rIP_var != NULL_RIP_VAR_OFFSET) {
 				jMax = tramp_list[nFunc_InBlk].saved_code_len - 4;
 				for (j = jMax - 2; j <= jMax; j++) {
@@ -741,7 +801,9 @@ install_hook(void)
 				    ((int)(((long int)(tramp_list[nFunc_InBlk].addr_org_func) -
 					    (long int)(tramp_list[nFunc_InBlk].trampoline))));
 			}
-
+#elif defined(__aarch64__)
+			// TODO: need to add the code to handle relative PC offset
+#endif
 			/* set up function pointers for original functions */
 			/* tramp_list[].trampoline holds the entry address */
 			/* to call original function                        */
@@ -760,7 +822,7 @@ install_hook(void)
 				       module_list[idx_mod].func_name_list[iFunc]);
 				exit(1);
 			}
-
+#if defined(__x86_64__)
 			/* save original code for uninstall */
 			memcpy(tramp_list[nFunc_InBlk].org_code,
 			       tramp_list[nFunc_InBlk].addr_org_func, 5);
@@ -770,6 +832,15 @@ install_hook(void)
 			*((int *)(pOpOrgEntry + 1)) =
 			    (int)((long int)(tramp_list[nFunc_InBlk].bounce) -
 				  (long int)(tramp_list[nFunc_InBlk].addr_org_func) - 5);
+#elif defined(__aarch64__)
+			/* save original code for uninstall */
+			memcpy(tramp_list[nFunc_InBlk].org_code,
+			       tramp_list[nFunc_InBlk].addr_org_func, 4);
+			
+			offset = (uint32_t) ((void*)&tramp_list[nFunc_InBlk].bounce - tramp_list[nFunc_InBlk].addr_org_func);
+			current_op = b_op | offset >> 2;
+			memcpy(tramp_list[nFunc_InBlk].addr_org_func, &current_op, sizeof(current_op));
+#endif
 
 			if (mprotect(pbaseOrg, MemSize_Modify, PROT_READ | PROT_EXEC) != 0) {
 				printf("Error in executing mprotect(). %s\n",

--- a/src/hook.c
+++ b/src/hook.c
@@ -627,6 +627,11 @@ install_hook(void)
 		printf("ERROR: Failed to initialize engine!\n");
 		exit(1);
 	}
+    cs_opt_skipdata skipdata = {
+       .mnemonic = "db",
+    };
+    cs_option(handle, CS_OPT_SKIPDATA, CS_OPT_ON);
+    cs_option(handle, CS_OPT_SKIPDATA_SETUP, (size_t)&skipdata);
 
 	for (idx_mod = 0; idx_mod < num_module; idx_mod++) {
 		tramp_list =

--- a/src/hook_int.h
+++ b/src/hook_int.h
@@ -32,7 +32,11 @@
  * ff 25 00 00 00 00       jmp    QWORD PTR [rip+0x0]     6 bytes
  * 8 bytes for the address of new function.
  */
-#define BOUNCE_CODE_LEN        (14)
+#if defined(__x86_64__)
+	#define BOUNCE_CODE_LEN        (14)
+#elif defined(__aarch64__)
+	#define BOUNCE_CODE_LEN        (16)
+#endif
 
 /**
  * The relative offset of new function address in bouncing code. It is after
@@ -44,10 +48,18 @@
 #define MAX_LEN_TO_DISASSEMBLE (24)
 
 /* The max length of an instruction */
-#define MAX_INSN_LEN           (15)
+#if defined(__x86_64__)
+	#define MAX_INSN_LEN        (15)
+#elif defined(__aarch64__)
+	#define MAX_INSN_LEN        (4)
+#endif
 
 /* The length of jmp instruction we use. */
-#define JMP_INSTRCTION_LEN     (5)
+#if defined(__x86_64__)
+	#define JMP_INSTRCTION_LEN        (5)
+#elif defined(__aarch64__)
+	#define JMP_INSTRCTION_LEN        (4)
+#endif
 
 /**
  * The max length of bytes to hold the instruments to call original function.


### PR DESCRIPTION
I ran into an error when running the example case on a Ubuntu system, which failed as below:
```
$ LD_PRELOAD=./hook_open.so python3 ./test/hello.py
Failed to disassemble code.
```
This is apparently from: https://github.com/wiliamhuang/linux_hook_libcapstone/blob/450c9d5d7cd0e75f5c65f138d62d6ace5f01b55e/src/hook.c#L664-L670

After debugging, I can see that `tramp_list[nFunc_InBlk].addr_org_func` points to the correct address of the open function, but the assembly code of that section is like:
```
   0x7ffff7e8be50 <__libc_open64>:      endbr64 
   0x7ffff7e8be54 <__libc_open64+4>:    push   %r12
   0x7ffff7e8be56 <__libc_open64+6>:    mov    %esi,%r10d
   0x7ffff7e8be59 <__libc_open64+9>:    mov    %esi,%r12d
   ...
``` 
which starts with a `endbr64`. By looking at libcapstone's [release node](https://www.capstone-engine.org/changelog.html), I can see that it starts supporting the `endbr64` at version 4.0.1, and the default version installed by apt in Ubuntu is 3.0.5. So it stops disassembling the code right at the beginning. 

The fix here is then simple. We just use the skip data feature of capstone to skip these uninterpreted instructions. 